### PR TITLE
Add Ukrainian layout

### DIFF
--- a/app/src/main/java/se/nullable/flickboard/model/layouts/UKMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/UKMessagEase.kt
@@ -7,89 +7,40 @@ import se.nullable.flickboard.model.Direction
 import se.nullable.flickboard.model.KeyM
 import se.nullable.flickboard.model.Layer
 import se.nullable.flickboard.model.Layout
+import se.nullable.flickboard.model.layouts.RU_MESSAGEASE_MAIN_LAYER
 import se.nullable.flickboard.ui.FlickBoardParent
 import se.nullable.flickboard.ui.Keyboard
 
 val UK_MESSAGEASE_MAIN_LAYER = Layer(
     keyRows = listOf(
         listOf(
-            KeyM(
-                actions = mapOf(
-                    Direction.CENTER to Action.Text("с"),
-                    Direction.BOTTOM to Action.Text("ц"),
-                    Direction.BOTTOM_RIGHT to Action.Text("п")
-                )
-            ),
-            KeyM(
-                actions = mapOf(
-                    Direction.TOP to Action.Text("й"),
-                    Direction.CENTER to Action.Text("и"),
-                    Direction.BOTTOM to Action.Text("к")
-                )
-            ),
-            KeyM(
-                actions = mapOf(
-                    Direction.CENTER to Action.Text("т"),
-                    Direction.BOTTOM_LEFT to Action.Text("ь")
-                )
-            ),
+            KeyM(actions = mapOf()),
+            KeyM(actions = mapOf()),
+            KeyM(actions = mapOf()),
         ),
         listOf(
             KeyM(
                 actions = mapOf(
-                    Direction.CENTER to Action.Text("в"),
-                    Direction.TOP to Action.Text("б"),
                     Direction.RIGHT to Action.Text("і"),
                     Direction.BOTTOM to Action.Text("ґ")
                 )
             ),
-            KeyM(
-                actions = mapOf(
-                    Direction.CENTER to Action.Text("о"),
-                    Direction.TOP_LEFT to Action.Text("ч"),
-                    Direction.TOP to Action.Text("м"),
-                    Direction.TOP_RIGHT to Action.Text("х"),
-                    Direction.LEFT to Action.Text("ж"),
-                    Direction.RIGHT to Action.Text("г"),
-                    Direction.BOTTOM_LEFT to Action.Text("щ"),
-                    Direction.BOTTOM to Action.Text("я"),
-                    Direction.BOTTOM_RIGHT to Action.Text("ш")
-                )
-            ),
-            KeyM(
-                actions = mapOf(
-                    Direction.CENTER to Action.Text("а"),
-                    Direction.LEFT to Action.Text("л")
-                )
-            ),
+            KeyM(actions = mapOf()),
+            KeyM(actions = mapOf()),
         ),
         listOf(
             KeyM(
                 actions = mapOf(
-                    Direction.CENTER to Action.Text("е"),
                     Direction.TOP to Action.Text("ї"),
-                    Direction.TOP_RIGHT to Action.Text("д"),
                     Direction.RIGHT to Action.Text("є")
                 )
             ),
-            KeyM(
-                actions = mapOf(
-                    Direction.CENTER to Action.Text("р"),
-                    Direction.LEFT to Action.Text("ю"),
-                    Direction.TOP to Action.Text("у"),
-                    Direction.RIGHT to Action.Text("з")
-                )
-            ),
-            KeyM(
-                actions = mapOf(
-                    Direction.CENTER to Action.Text("н"),
-                    Direction.TOP_LEFT to Action.Text("ф")
-                )
-            ),
+            KeyM(actions = mapOf()),
+            KeyM(actions = mapOf()),
         ),
         listOf(SPACE)
     )
-)
+).mergeFallback(RU_MESSAGEASE_MAIN_LAYER)
 
 val UK_MESSAGEASE = Layout(
     mainLayer = UK_MESSAGEASE_MAIN_LAYER,

--- a/app/src/main/java/se/nullable/flickboard/model/layouts/UKMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/UKMessagEase.kt
@@ -1,0 +1,113 @@
+package se.nullable.flickboard.model.layouts
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import se.nullable.flickboard.model.Action
+import se.nullable.flickboard.model.Direction
+import se.nullable.flickboard.model.KeyM
+import se.nullable.flickboard.model.Layer
+import se.nullable.flickboard.model.Layout
+import se.nullable.flickboard.ui.FlickBoardParent
+import se.nullable.flickboard.ui.Keyboard
+
+val UK_MESSAGEASE_MAIN_LAYER = Layer(
+    keyRows = listOf(
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("с"),
+                    Direction.BOTTOM to Action.Text("ц"),
+                    Direction.BOTTOM_RIGHT to Action.Text("п")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.TOP to Action.Text("й"),
+                    Direction.CENTER to Action.Text("и"),
+                    Direction.BOTTOM to Action.Text("к")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("т"),
+                    Direction.BOTTOM_LEFT to Action.Text("ь")
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("в"),
+                    Direction.TOP to Action.Text("б"),
+                    Direction.RIGHT to Action.Text("і"),
+                    Direction.BOTTOM to Action.Text("ґ")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("о"),
+                    Direction.TOP_LEFT to Action.Text("ч"),
+                    Direction.TOP to Action.Text("м"),
+                    Direction.TOP_RIGHT to Action.Text("х"),
+                    Direction.LEFT to Action.Text("ж"),
+                    Direction.RIGHT to Action.Text("г"),
+                    Direction.BOTTOM_LEFT to Action.Text("щ"),
+                    Direction.BOTTOM to Action.Text("я"),
+                    Direction.BOTTOM_RIGHT to Action.Text("ш")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("а"),
+                    Direction.LEFT to Action.Text("л")
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("е"),
+                    Direction.TOP to Action.Text("ї"),
+                    Direction.TOP_RIGHT to Action.Text("д"),
+                    Direction.RIGHT to Action.Text("є")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("р"),
+                    Direction.LEFT to Action.Text("ю"),
+                    Direction.TOP to Action.Text("у"),
+                    Direction.RIGHT to Action.Text("з")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("н"),
+                    Direction.TOP_LEFT to Action.Text("ф")
+                )
+            ),
+        ),
+        listOf(SPACE)
+    )
+)
+
+val UK_MESSAGEASE = Layout(
+    mainLayer = UK_MESSAGEASE_MAIN_LAYER,
+    controlLayer = CONTROL_MESSAGEASE_LAYER
+)
+
+@Composable
+@Preview
+fun UkKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = Layout(UK_MESSAGEASE_MAIN_LAYER), onAction = {})
+    }
+}
+
+@Composable
+@Preview
+fun UkFullKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = UK_MESSAGEASE, onAction = {})
+    }
+}

--- a/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
+++ b/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
@@ -72,6 +72,7 @@ import se.nullable.flickboard.model.layouts.MESSAGEASE_NUMERIC_CALCULATOR_LAYER
 import se.nullable.flickboard.model.layouts.MESSAGEASE_NUMERIC_PHONE_LAYER
 import se.nullable.flickboard.model.layouts.RU_MESSAGEASE
 import se.nullable.flickboard.model.layouts.SV_MESSAGEASE
+import se.nullable.flickboard.model.layouts.UK_MESSAGEASE
 import kotlin.math.roundToInt
 
 @Composable
@@ -657,6 +658,7 @@ enum class LetterLayerOption(override val label: String, val layout: Layout) : L
     Swedish("Swedish (MessagEase)", SV_MESSAGEASE),
     German("German (MessagEase)", DE_MESSAGEASE),
     Russian("Russian (MessagEase)", RU_MESSAGEASE),
+    Ukrainian("Ukrainian (MessagEase)", UK_MESSAGEASE),
 }
 
 enum class NumericLayerOption(override val label: String, val layer: Layer) : Labeled {


### PR DESCRIPTION
Closes #37.

In MessagEase, Ukrainian seems to be implemented as Russian with just 4 letters overridden, but it looks like we don’t have that kind of deduplication in FlickBoard (yet?).