### PR TITLE
Allow clockwise gesture for select-all in clockwise-numbers mode

### DIFF
--- a/app/src/main/java/se/nullable/flickboard/model/layouts/CommonMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/CommonMessagEase.kt
@@ -56,6 +56,7 @@ val CONTROL_MESSAGEASE_LAYER =
                         Direction.TOP_RIGHT to Action.Cut,
                         Direction.BOTTOM to Action.Paste,
                     ),
+                    holdAction = Action.SelectAll,
                     shift = KeyM(actions = mapOf(Direction.CENTER to Action.SelectAll)),
                 )
             ),


### PR DESCRIPTION
In the original Messagease layout, a circle in either direction on the clipboard key would result in a select-all, but the present layout ignores the clockwise gesture when "Type digit on clockwise circle" is enabled. Add the clockwise gesture explicitly for parity.

## Considerations
Since long-press and clockwise-circle are configured as a single action or letter in the current structure, this has the possibly-undesirable side effect of adding the select-all action to long-press (which Messagease used for its quick-text feature). 

An alternate option might be to use the `shift` behavior on a key instead of the `holdAction` behavior  in clockwise-digits mode when no `holdAction` is specified. 