### PR TITLE
Fixes crash on emoji menu in older Android versions

### DIFF
--- a/app/src/main/java/se/nullable/flickboard/ui/emoji/EmojiKeyboard.kt
+++ b/app/src/main/java/se/nullable/flickboard/ui/emoji/EmojiKeyboard.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.res.getResourceIdOrThrow
+import androidx.core.content.res.use
 import se.nullable.flickboard.R
 import se.nullable.flickboard.model.Action
 import androidx.emoji2.emojipicker.R as Emoji2R


### PR DESCRIPTION
On Android 11 (and possibly other versions), opening the emoji keyboard raises ClassCastException, apparently because TypedArray does not implement `use` in older versions. Remedy this with a backwards-compatible library import.

Reference - https://stackoverflow.com/a/73502339