### PR TITLE
MessagEase Russian-phonetic layout.

### DIFF
--- a/app/src/main/java/se/nullable/flickboard/model/layouts/RUPHMessageEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/RUPHMessageEase.kt
@@ -40,7 +40,7 @@ val RU_PHONETIC_MESSAGEASE_MAIN_LAYER = Layer(
                     Direction.CENTER to Action.Text("в"),
                     Direction.TOP to Action.Text("ъ"),
                     Direction.RIGHT to Action.Text("к"),
-                    Direction.BOTTOM to Action.Text("ь")
+                    Direction.BOTTOM to Action.Text("ь"),
                     Direction.BOTTOM_RIGHT to Action.Text("ы")
                 )
             ),

--- a/app/src/main/java/se/nullable/flickboard/model/layouts/RUPHMessageEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/RUPHMessageEase.kt
@@ -1,0 +1,114 @@
+package se.nullable.flickboard.model.layouts
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import se.nullable.flickboard.model.Action
+import se.nullable.flickboard.model.Direction
+import se.nullable.flickboard.model.KeyM
+import se.nullable.flickboard.model.Layer
+import se.nullable.flickboard.model.Layout
+import se.nullable.flickboard.ui.FlickBoardParent
+import se.nullable.flickboard.ui.Keyboard
+
+val RU_PHONETIC_MESSAGEASE_MAIN_LAYER = Layer(
+    keyRows = listOf(
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("а"),
+                    Direction.BOTTOM to Action.Text("ч"),
+                    Direction.BOTTOM_RIGHT to Action.Text("ж")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.TOP to Action.Text("й"),
+                    Direction.CENTER to Action.Text("н"),
+                    Direction.BOTTOM to Action.Text("л")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("и"),
+                    Direction.BOTTOM_LEFT to Action.Text("х")
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("в"),
+                    Direction.TOP to Action.Text("ъ"),
+                    Direction.RIGHT to Action.Text("к"),
+                    Direction.BOTTOM to Action.Text("ь")
+                    Direction.BOTTOM_RIGHT to Action.Text("ы")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("о"),
+                    Direction.TOP_LEFT to Action.Text("я"),
+                    Direction.TOP to Action.Text("у"),
+                    Direction.TOP_RIGHT to Action.Text("п"),
+                    Direction.LEFT to Action.Text("ц"),
+                    Direction.RIGHT to Action.Text("б"),
+                    Direction.BOTTOM_LEFT to Action.Text("г"),
+                    Direction.BOTTOM to Action.Text("д"),
+                    Direction.BOTTOM_RIGHT to Action.Text("й")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("р"),
+                    Direction.LEFT to Action.Text("м")
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("т"),
+                    Direction.TOP to Action.Text("ё"),
+                    Direction.TOP_RIGHT to Action.Text("ю"),
+                    Direction.RIGHT to Action.Text("щ")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("е"),
+                    Direction.LEFT to Action.Text("ш"),
+                    Direction.TOP to Action.Text("э"),
+                    Direction.RIGHT to Action.Text("з")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("с"),
+                    Direction.TOP_LEFT to Action.Text("ф")
+                )
+            ),
+        ),
+        listOf(SPACE)
+    )
+)
+
+val RU_PHONETIC_MESSAGEASE = Layout(
+    mainLayer = RU_PHONETIC_MESSAGEASE_MAIN_LAYER,
+    controlLayer = CONTROL_MESSAGEASE_LAYER
+)
+
+@Composable
+@Preview
+fun RuPhKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = Layout(RU_PHONETIC_MESSAGEASE_MAIN_LAYER), onAction = {})
+    }
+}
+
+@Composable
+@Preview
+fun RuPhFullKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = RU_PHONETIC_MESSAGEASE, onAction = {})
+    }
+}

--- a/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
+++ b/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
@@ -887,7 +887,7 @@ enum class LetterLayerOption(override val label: String, val layout: Layout) : L
     German("German (MessagEase)", DE_MESSAGEASE),
     GermanEnglish("German/English (MessagEase)", EN_DE_MESSAGEASE),
     Russian("Russian (MessagEase)", RU_MESSAGEASE),
-    Russian("Russian phonetic (MessagEase)", RU_PHONETIC_MESSAGEASE),
+    RussianPhonetic("Russian phonetic (MessagEase)", RU_PHONETIC_MESSAGEASE),
     Spanish("Spanish (MessagEase)", ES_MESSAGEASE),
     Swedish("Swedish (MessagEase)", SV_MESSAGEASE),
     SwedishDE("Swedish (MessagEase, German-style)", SV_DE_MESSAGEASE),

--- a/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
+++ b/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
@@ -84,6 +84,7 @@ import se.nullable.flickboard.model.layouts.FR_MESSAGEASE
 import se.nullable.flickboard.model.layouts.MESSAGEASE_NUMERIC_CALCULATOR_LAYER
 import se.nullable.flickboard.model.layouts.MESSAGEASE_NUMERIC_PHONE_LAYER
 import se.nullable.flickboard.model.layouts.RU_MESSAGEASE
+import se.nullable.flickboard.model.layouts.RU_PHONETIC_MESSAGEASE
 import se.nullable.flickboard.model.layouts.SV_DE_MESSAGEASE
 import se.nullable.flickboard.model.layouts.SV_MESSAGEASE
 import se.nullable.flickboard.model.layouts.UK_MESSAGEASE
@@ -886,6 +887,7 @@ enum class LetterLayerOption(override val label: String, val layout: Layout) : L
     German("German (MessagEase)", DE_MESSAGEASE),
     GermanEnglish("German/English (MessagEase)", EN_DE_MESSAGEASE),
     Russian("Russian (MessagEase)", RU_MESSAGEASE),
+    Russian("Russian phonetic (MessagEase)", RU_PHONETIC_MESSAGEASE),
     Spanish("Spanish (MessagEase)", ES_MESSAGEASE),
     Swedish("Swedish (MessagEase)", SV_MESSAGEASE),
     SwedishDE("Swedish (MessagEase, German-style)", SV_DE_MESSAGEASE),


### PR DESCRIPTION
I contributed this layout to MessagEase in 2013.  It allows to conventiently type in Cyrillic without having to learn yet another completely new layout.   I use this on a regular basis.

I haven't compiled or tested this, just copied the RU layout and changed the letters.

I'm not sure about the naming of the file nor the functions.  Feel free to change that!