### PR TITLE
Add alternative french layout

### DIFF
--- a/app/src/main/java/se/nullable/flickboard/model/layouts/FRAlt.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/FRAlt.kt
@@ -1,0 +1,119 @@
+package se.nullable.flickboard.model.layouts
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import se.nullable.flickboard.model.Action
+import se.nullable.flickboard.model.Direction
+import se.nullable.flickboard.model.KeyM
+import se.nullable.flickboard.model.Layer
+import se.nullable.flickboard.model.Layout
+import se.nullable.flickboard.ui.FlickBoardParent
+import se.nullable.flickboard.ui.Keyboard
+
+val FR_ALT_MAIN_LAYER = Layer(
+    keyRows = listOf(
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("a"),
+                    Direction.TOP_LEFT to Action.Text("ï"),
+                    Direction.TOP to Action.Text("à"),
+                    Direction.TOP_RIGHT to Action.Text("â"),
+                    Direction.LEFT to Action.Text("ç"),
+                    Direction.BOTTOM_RIGHT to Action.Text("v"),
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("n"),
+                    Direction.BOTTOM to Action.Text("z"),
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("i"),
+                    Direction.TOP_LEFT to Action.Text("û"),
+                    Direction.TOP_RIGHT to Action.Text("ô"),
+                    Direction.RIGHT to Action.Text("î"),
+                    Direction.BOTTOM_LEFT to Action.Text("x"),
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("l"),
+                    Direction.TOP to Action.Text("ù"),
+                    Direction.RIGHT to Action.Text("h"),
+                    Direction.BOTTOM to Action.Text("w"),
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("o"),
+                    Direction.TOP_LEFT to Action.Text("q"),
+                    Direction.TOP to Action.Text("u"),
+                    Direction.TOP_RIGHT to Action.Text("p"),
+                    Direction.LEFT to Action.Text("c"),
+                    Direction.RIGHT to Action.Text("b"),
+                    Direction.BOTTOM_LEFT to Action.Text("g"),
+                    Direction.BOTTOM to Action.Text("d"),
+                    Direction.BOTTOM_RIGHT to Action.Text("j"),
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("r"),
+                    Direction.LEFT to Action.Text("m"),
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("t"),
+                    Direction.TOP_RIGHT to Action.Text("y"),
+                    Direction.BOTTOM_LEFT to Action.Text("ë"),
+                    Direction.BOTTOM to Action.Text("k"),
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("e"),
+                    Direction.TOP to Action.Text("é"),
+                    Direction.LEFT to Action.Text("è"),
+                    Direction.RIGHT to Action.Text("ê")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("s"),
+                    Direction.TOP_LEFT to Action.Text("f"),
+                    Direction.BOTTOM_RIGHT to Action.Text("ü")
+                )
+            ),
+        ),
+        listOf(SPACE)
+    )
+)
+
+val FR_ALT = Layout(
+    mainLayer = FR_ALT_MAIN_LAYER,
+    controlLayer = CONTROL_MESSAGEASE_LAYER
+)
+
+@Composable
+@Preview
+fun FrAltKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = Layout(FR_ALT_MAIN_LAYER), onAction = {})
+    }
+}
+
+@Composable
+@Preview
+fun FrAltFullKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = FR_ALT, onAction = {})
+    }
+}

--- a/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
+++ b/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
@@ -88,6 +88,7 @@ import se.nullable.flickboard.model.layouts.EN_DE_MESSAGEASE
 import se.nullable.flickboard.model.layouts.EN_MESSAGEASE
 import se.nullable.flickboard.model.layouts.ES_MESSAGEASE
 import se.nullable.flickboard.model.layouts.FR_MESSAGEASE
+import se.nullable.flickboard.model.layouts.FR_ALT
 import se.nullable.flickboard.model.layouts.MESSAGEASE_NUMERIC_CALCULATOR_LAYER
 import se.nullable.flickboard.model.layouts.MESSAGEASE_NUMERIC_PHONE_LAYER
 import se.nullable.flickboard.model.layouts.RU_MESSAGEASE
@@ -954,6 +955,7 @@ enum class LetterLayerOption(override val label: String, val layout: Layout) : L
     SwedishDE("Swedish (MessagEase, German-style)", SV_DE_MESSAGEASE),
     Ukrainian("Ukrainian (MessagEase)", UK_MESSAGEASE),
     French("French (MessagEase)", FR_MESSAGEASE),
+    FrenchAlt("French (Alternative)", FR_ALT),
 }
 
 enum class NumericLayerOption(override val label: String, val layer: Layer) : Labeled {


### PR DESCRIPTION
This fixes #76

I'm very new to PR and have never written .kt code. I also did not test my code as I didn't know how to (I just changed the code in Codespace and that's it!)

This is how the layout should look like:
![French layout](https://github.com/nightkr/flickboard/assets/30509883/3db7d0f1-106e-4995-a37c-8a731e189c15)

Please review carefully!
And let me know if I did anything wrong, to help me improve 👍 