### PR TITLE
Add UkrainianRussian layout

### DIFF
--- a/app/src/main/java/se/nullable/flickboard/model/layouts/UKRUMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/UKRUMessagEase.kt
@@ -1,0 +1,115 @@
+package se.nullable.flickboard.model.layouts
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import se.nullable.flickboard.model.Action
+import se.nullable.flickboard.model.Direction
+import se.nullable.flickboard.model.KeyM
+import se.nullable.flickboard.model.Layer
+import se.nullable.flickboard.model.Layout
+import se.nullable.flickboard.ui.FlickBoardParent
+import se.nullable.flickboard.ui.Keyboard
+
+val UK_RU_MESSAGEASE_MAIN_LAYER = Layer(
+    keyRows = listOf(
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("с"),
+                    Direction.BOTTOM to Action.Text("ц"),
+                    Direction.BOTTOM_RIGHT to Action.Text("п")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.TOP to Action.Text("й"),
+                    Direction.CENTER to Action.Text("и"),
+                    Direction.BOTTOM to Action.Text("к")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("т"),
+                    Direction.BOTTOM_LEFT to Action.Text("ь")
+                    Direction.BOTTOM_RIGHT to Action.Text("э")
+                )
+            ),
+        ),
+        LISTOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("в"),
+                    Direction.TOP to Action.Text("б"),
+                    Direction.RIGHT to Action.Text("ы"),
+                    Direction.BOTTOM to Action.Text("і")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("о"),
+                    Direction.TOP_LEFT to Action.Text("ч"),
+                    Direction.TOP to Action.Text("м"),
+                    Direction.TOP_RIGHT to Action.Text("х"),
+                    Direction.LEFT to Action.Text("ж"),
+                    Direction.RIGHT to Action.Text("г"),
+                    Direction.BOTTOM_LEFT to Action.Text("щ"),
+                    Direction.BOTTOM to Action.Text("я"),
+                    Direction.BOTTOM_RIGHT to Action.Text("ш")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("а"),
+                    Direction.LEFT to Action.Text("л")
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("е"),
+                    Direction.TOP to Action.Text("ї"),
+                    Direction.TOP_RIGHT to Action.Text("д"),
+                    Direction.RIGHT to Action.Text("є")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("р"),
+                    Direction.LEFT to Action.Text("ю"),
+                    Direction.TOP to Action.Text("у"),
+                    Direction.RIGHT to Action.Text("з")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("н"),
+                    Direction.TOP_LEFT to Action.Text("ф")
+                    Direction.TOP_RIGHT to Action.Text("ё")
+                )
+            ),
+        ),
+        listOf(SPACE)
+    )
+)
+
+val UK_RU_MESSAGEASE = Layout(
+    mainLayer = UK_RU_MESSAGEASE_MAIN_LAYER,
+    controlLayer = CONTROL_MESSAGEASE_LAYER
+)
+
+@Composable
+@Preview
+fun UkRuKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = Layout(UK_RU_MESSAGEASE_MAIN_LAYER), onAction = {})
+    }
+}
+
+@Composable
+@Preview
+fun UkRuFullKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = UK_RU_MESSAGEASE, onAction = {})
+    }
+}

--- a/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
+++ b/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
@@ -95,6 +95,7 @@ import se.nullable.flickboard.model.layouts.RU_PHONETIC_MESSAGEASE
 import se.nullable.flickboard.model.layouts.SV_DE_MESSAGEASE
 import se.nullable.flickboard.model.layouts.SV_MESSAGEASE
 import se.nullable.flickboard.model.layouts.UK_MESSAGEASE
+import se.nullable.flickboard.model.layouts.UK_RU_MESSAGEASE
 import se.nullable.flickboard.util.Boxed
 import java.io.FileOutputStream
 import kotlin.math.roundToInt
@@ -970,6 +971,7 @@ enum class LetterLayerOption(override val label: String, val layout: Layout) : L
     Swedish("Swedish (MessagEase)", SV_MESSAGEASE),
     SwedishDE("Swedish (MessagEase, German-style)", SV_DE_MESSAGEASE),
     Ukrainian("Ukrainian (MessagEase)", UK_MESSAGEASE),
+    UkrainianRussian("Ukrainian Russian (MessagEase)", UK_RU_MESSAGEASE),
     French("French (MessagEase)", FR_MESSAGEASE),
 }
 


### PR DESCRIPTION
I want to thank you for such amazing project.
In order to use it fully I need UkrainianRussian layout, as the difference between two alphabets is only few letters. I've created it in MessageEase keyboard and added it to [Thumb-key](https://github.com/dessalines/thumb-key/pull/465) project as well. And I really miss some features from MessageEase, so I hope your project will be the best of all worlds.

Unfortunately I'm not android developer, so I just copy RU layout and did small changes, same as in Thumb-key project. I hope it will build without issues. 