### PR TITLE
Hungarian, Italian, Portuguese and Turkish layouts

### DIFF
--- a/app/src/main/java/se/nullable/flickboard/model/layouts/HUDTMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/HUDTMessagEase.kt
@@ -1,0 +1,115 @@
+package se.nullable.flickboard.model.layouts
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import se.nullable.flickboard.model.Action
+import se.nullable.flickboard.model.Direction
+import se.nullable.flickboard.model.KeyM
+import se.nullable.flickboard.model.Layer
+import se.nullable.flickboard.model.Layout
+import se.nullable.flickboard.ui.FlickBoardParent
+import se.nullable.flickboard.ui.Keyboard
+
+val HU_DT_MESSAGEASE_MAIN_LAYER = Layer(
+    keyRows = listOf(
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("a"),
+                    Direction.BOTTOM_RIGHT to Action.Text("v")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("n"),
+                    Direction.TOP_LEFT to Action.Text("á"),
+                    Direction.TOP_RIGHT to Action.Text("é"),
+                    Direction.BOTTOM_LEFT to Action.Text("ú"),
+                    Direction.BOTTOM to Action.Text("l"),
+                    Direction.BOTTOM_RIGHT to Action.Text("ó")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("i"),
+                    Direction.BOTTOM_LEFT to Action.Text("x"),
+                    Direction.BOTTOM_RIGHT to Action.Text("í")
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("h"),
+                    Direction.TOP_RIGHT to Action.Text("ü"),
+                    Direction.RIGHT to Action.Text("k"),
+                    Direction.BOTTOM_RIGHT to Action.Text("ű")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("o"),
+                    Direction.TOP_LEFT to Action.Text("q"),
+                    Direction.TOP to Action.Text("u"),
+                    Direction.TOP_RIGHT to Action.Text("p"),
+                    Direction.LEFT to Action.Text("c"),
+                    Direction.RIGHT to Action.Text("b"),
+                    Direction.BOTTOM_LEFT to Action.Text("g"),
+                    Direction.BOTTOM to Action.Text("d"),
+                    Direction.BOTTOM_RIGHT to Action.Text("j")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("r"),
+                    Direction.TOP_LEFT to Action.Text("ö"),
+                    Direction.TOP_RIGHT to Action.Text("ő"),
+                    Direction.LEFT to Action.Text("m")
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("t"),
+                    Direction.TOP_RIGHT to Action.Text("y")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("e"),
+                    Direction.TOP to Action.Text("w"),
+                    Direction.RIGHT to Action.Text("z")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("s"),
+                    Direction.TOP_LEFT to Action.Text("f")
+                )
+            ),
+        ),
+        listOf(SPACE)
+    )
+)
+
+val HU_DT_MESSAGEASE = Layout(
+    mainLayer = HU_DT_MESSAGEASE_MAIN_LAYER,
+    controlLayer = CONTROL_MESSAGEASE_LAYER
+)
+
+@Composable
+@Preview
+fun HuDtKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = Layout(HU_DT_MESSAGEASE_MAIN_LAYER), onAction = {})
+    }
+}
+
+@Composable
+@Preview
+fun HuDtFullKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = HU_DT_MESSAGEASE, onAction = {})
+    }
+}

--- a/app/src/main/java/se/nullable/flickboard/model/layouts/HUDTMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/HUDTMessagEase.kt
@@ -1,3 +1,5 @@
+// HU DT refers to: Hungarian MessagEase community layout, made by Dániel Tenke
+
 package se.nullable.flickboard.model.layouts
 
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/se/nullable/flickboard/model/layouts/HUMFMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/HUMFMessagEase.kt
@@ -1,3 +1,5 @@
+// HU MF refers to: Hungarian MessagEase community layout, made by Máté Farkas
+
 package se.nullable.flickboard.model.layouts
 
 import androidx.compose.runtime.Composable

--- a/app/src/main/java/se/nullable/flickboard/model/layouts/HUMFMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/HUMFMessagEase.kt
@@ -1,0 +1,115 @@
+package se.nullable.flickboard.model.layouts
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import se.nullable.flickboard.model.Action
+import se.nullable.flickboard.model.Direction
+import se.nullable.flickboard.model.KeyM
+import se.nullable.flickboard.model.Layer
+import se.nullable.flickboard.model.Layout
+import se.nullable.flickboard.ui.FlickBoardParent
+import se.nullable.flickboard.ui.Keyboard
+
+val HU_MF_MESSAGEASE_MAIN_LAYER = Layer(
+    keyRows = listOf(
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("a"),
+                    Direction.BOTTOM to Action.Text("á"),
+                    Direction.BOTTOM_RIGHT to Action.Text("v")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("n"),
+                    Direction.BOTTOM to Action.Text("l")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("i"),
+                    Direction.BOTTOM_LEFT to Action.Text("x"),
+                    Direction.BOTTOM to Action.Text("í"),
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("h"),
+                    Direction.TOP to Action.Text("ú"),
+                    Direction.TOP_RIGHT to Action.Text("ö"),
+                    Direction.RIGHT to Action.Text("k"),
+                    Direction.BOTTOM to Action.Text("ó"),
+                    Direction.BOTTOM_RIGHT to Action.Text("ő")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("o"),
+                    Direction.TOP_LEFT to Action.Text("q"),
+                    Direction.TOP to Action.Text("u"),
+                    Direction.TOP_RIGHT to Action.Text("p"),
+                    Direction.LEFT to Action.Text("c"),
+                    Direction.RIGHT to Action.Text("b"),
+                    Direction.BOTTOM_LEFT to Action.Text("g"),
+                    Direction.BOTTOM to Action.Text("d"),
+                    Direction.BOTTOM_RIGHT to Action.Text("j"),
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("r"),
+                    Direction.TOP_LEFT to Action.Text("ü"),
+                    Direction.LEFT to Action.Text("m"),
+                    Direction.BOTTOM_LEFT to Action.Text("ű")
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("t"),
+                    Direction.TOP_RIGHT to Action.Text("y"),
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("e"),
+                    Direction.TOP to Action.Text("w"),
+                    Direction.LEFT to Action.Text("é"),
+                    Direction.RIGHT to Action.Text("z")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("s"),
+                    Direction.TOP_LEFT to Action.Text("f")
+                )
+            ),
+        ),
+        listOf(SPACE)
+    )
+)
+
+val HU_MF_MESSAGEASE = Layout(
+    mainLayer = HU_MF_MESSAGEASE_MAIN_LAYER,
+    controlLayer = CONTROL_MESSAGEASE_LAYER
+)
+
+@Composable
+@Preview
+fun HuMfKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = Layout(HU_MF_MESSAGEASE_MAIN_LAYER), onAction = {})
+    }
+}
+
+@Composable
+@Preview
+fun HuMfFullKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = HU_MF_MESSAGEASE, onAction = {})
+    }
+}

--- a/app/src/main/java/se/nullable/flickboard/model/layouts/HUMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/HUMessagEase.kt
@@ -1,0 +1,115 @@
+package se.nullable.flickboard.model.layouts
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import se.nullable.flickboard.model.Action
+import se.nullable.flickboard.model.Direction
+import se.nullable.flickboard.model.KeyM
+import se.nullable.flickboard.model.Layer
+import se.nullable.flickboard.model.Layout
+import se.nullable.flickboard.ui.FlickBoardParent
+import se.nullable.flickboard.ui.Keyboard
+
+val HU_MESSAGEASE_MAIN_LAYER = Layer(
+    keyRows = listOf(
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("a"),
+                    Direction.TOP to Action.Text("á"),
+                    Direction.BOTTOM to Action.Text("ú"),
+                    Direction.BOTTOM_RIGHT to Action.Text("v")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("n"),
+                    Direction.BOTTOM to Action.Text("l")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("i"),
+                    Direction.TOP_LEFT to Action.Text("í"),
+                    Direction.RIGHT to Action.Text("ó"),
+                    Direction.BOTTOM_LEFT to Action.Text("x")
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("h"),
+                    Direction.TOP to Action.Text("ü"),
+                    Direction.RIGHT to Action.Text("k"),
+                    Direction.BOTTOM to Action.Text("ű")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("o"),
+                    Direction.TOP_LEFT to Action.Text("q"),
+                    Direction.TOP to Action.Text("u"),
+                    Direction.TOP_RIGHT to Action.Text("p"),
+                    Direction.LEFT to Action.Text("c"),
+                    Direction.RIGHT to Action.Text("b"),
+                    Direction.BOTTOM_LEFT to Action.Text("g"),
+                    Direction.BOTTOM to Action.Text("d"),
+                    Direction.BOTTOM_RIGHT to Action.Text("j"),
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("r"),
+                    Direction.LEFT to Action.Text("m"),
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("t"),
+                    Direction.TOP to Action.Text("ö"),
+                    Direction.TOP_RIGHT to Action.Text("y"),
+                    Direction.BOTTOM to Action.Text("ő")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("e"),
+                    Direction.TOP to Action.Text("w"),
+                    Direction.LEFT to Action.Text("é"),
+                    Direction.RIGHT to Action.Text("z")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("s"),
+                    Direction.TOP_LEFT to Action.Text("f")
+                )
+            ),
+        ),
+        listOf(SPACE)
+    )
+)
+
+val HU_MESSAGEASE = Layout(
+    mainLayer = HU_MESSAGEASE_MAIN_LAYER,
+    controlLayer = CONTROL_MESSAGEASE_LAYER
+)
+
+@Composable
+@Preview
+fun HuKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = Layout(HU_MESSAGEASE_MAIN_LAYER), onAction = {})
+    }
+}
+
+@Composable
+@Preview
+fun HuFullKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = HU_MESSAGEASE, onAction = {})
+    }
+}

--- a/app/src/main/java/se/nullable/flickboard/model/layouts/HUUUPMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/HUUUPMessagEase.kt
@@ -1,0 +1,115 @@
+package se.nullable.flickboard.model.layouts
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import se.nullable.flickboard.model.Action
+import se.nullable.flickboard.model.Direction
+import se.nullable.flickboard.model.KeyM
+import se.nullable.flickboard.model.Layer
+import se.nullable.flickboard.model.Layout
+import se.nullable.flickboard.ui.FlickBoardParent
+import se.nullable.flickboard.ui.Keyboard
+
+val HU_UUP_MESSAGEASE_MAIN_LAYER = Layer(
+    keyRows = listOf(
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("a"),
+                    Direction.TOP to Action.Text("ú"),
+                    Direction.TOP_RIGHT to Action.Text("á"),
+                    Direction.BOTTOM to Action.Text("ó"),
+                    Direction.BOTTOM_RIGHT to Action.Text("v")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("n"),
+                    Direction.BOTTOM to Action.Text("l")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("i"),
+                    Direction.TOP_LEFT to Action.Text("í"),
+                    Direction.BOTTOM_LEFT to Action.Text("x")
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("h"),
+                    Direction.TOP to Action.Text("ü"),
+                    Direction.RIGHT to Action.Text("k"),
+                    Direction.BOTTOM to Action.Text("ö")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("o"),
+                    Direction.TOP_LEFT to Action.Text("q"),
+                    Direction.TOP to Action.Text("u"),
+                    Direction.TOP_RIGHT to Action.Text("p"),
+                    Direction.LEFT to Action.Text("c"),
+                    Direction.RIGHT to Action.Text("b"),
+                    Direction.BOTTOM_LEFT to Action.Text("g"),
+                    Direction.BOTTOM to Action.Text("d"),
+                    Direction.BOTTOM_RIGHT to Action.Text("j"),
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("r"),
+                    Direction.LEFT to Action.Text("m"),
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("t"),
+                    Direction.TOP to Action.Text("ű"),
+                    Direction.TOP_RIGHT to Action.Text("y"),
+                    Direction.BOTTOM to Action.Text("ő")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("e"),
+                    Direction.TOP to Action.Text("w"),
+                    Direction.LEFT to Action.Text("é"),
+                    Direction.RIGHT to Action.Text("z")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("s"),
+                    Direction.TOP_LEFT to Action.Text("f")
+                )
+            ),
+        ),
+        listOf(SPACE)
+    )
+)
+
+val HU_UUP_MESSAGEASE = Layout(
+    mainLayer = HU_UUP_MESSAGEASE_MAIN_LAYER,
+    controlLayer = CONTROL_MESSAGEASE_LAYER
+)
+
+@Composable
+@Preview
+fun HuUUpKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = Layout(HU_UUP_MESSAGEASE_MAIN_LAYER), onAction = {})
+    }
+}
+
+@Composable
+@Preview
+fun HuUUpFullKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = HU_UUP_MESSAGEASE, onAction = {})
+    }
+}

--- a/app/src/main/java/se/nullable/flickboard/model/layouts/PTANDMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/PTANDMessagEase.kt
@@ -1,0 +1,115 @@
+package se.nullable.flickboard.model.layouts
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import se.nullable.flickboard.model.Action
+import se.nullable.flickboard.model.Direction
+import se.nullable.flickboard.model.KeyM
+import se.nullable.flickboard.model.Layer
+import se.nullable.flickboard.model.Layout
+import se.nullable.flickboard.ui.FlickBoardParent
+import se.nullable.flickboard.ui.Keyboard
+
+val PT_AND_MESSAGEASE_MAIN_LAYER = Layer(
+    keyRows = listOf(
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("a"),
+                    Direction.TOP to Action.Text("ô"),
+                    Direction.TOP_RIGHT to Action.Text("â"),
+                    Direction.LEFT to Action.Text("ã"),
+                    Direction.BOTTOM to Action.Text("á"),
+                    Direction.BOTTOM_RIGHT to Action.Text("v")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("n"),
+                    Direction.TOP to Action.Text("ñ"),
+                    Direction.BOTTOM to Action.Text("l")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("i"),
+                    Direction.RIGHT to Action.Text("õ"),
+                    Direction.BOTTOM_LEFT to Action.Text("x")
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("d"),
+                    Direction.RIGHT to Action.Text("k")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("o"),
+                    Direction.TOP_LEFT to Action.Text("q"),
+                    Direction.TOP to Action.Text("u"),
+                    Direction.TOP_RIGHT to Action.Text("p"),
+                    Direction.LEFT to Action.Text("c"),
+                    Direction.RIGHT to Action.Text("b"),
+                    Direction.BOTTOM_LEFT to Action.Text("g"),
+                    Direction.BOTTOM to Action.Text("h"),
+                    Direction.BOTTOM_RIGHT to Action.Text("j")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("r"),
+                    Direction.LEFT to Action.Text("m")
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("t"),
+                    Direction.TOP to Action.Text("ú"),
+                    Direction.TOP_RIGHT to Action.Text("y"),
+                    Direction.RIGHT to Action.Text("ê"),
+                    Direction.BOTTOM to Action.Text("ó")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("e"),
+                    Direction.TOP to Action.Text("w"),
+                    Direction.RIGHT to Action.Text("z")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("s"),
+                    Direction.TOP_LEFT to Action.Text("f")
+                )
+            ),
+        ),
+        listOf(SPACE)
+    )
+)
+
+val PT_AND_MESSAGEASE = Layout(
+    mainLayer = PT_AND_MESSAGEASE_MAIN_LAYER,
+    controlLayer = CONTROL_MESSAGEASE_LAYER
+)
+
+@Composable
+@Preview
+fun PtAndKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = Layout(PT_AND_MESSAGEASE_MAIN_LAYER), onAction = {})
+    }
+}
+
+@Composable
+@Preview
+fun PtAndFullKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = PT_AND_MESSAGEASE, showAllModifiers = true, onAction = {})
+    }
+}

--- a/app/src/main/java/se/nullable/flickboard/model/layouts/PTIOSMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/PTIOSMessagEase.kt
@@ -1,0 +1,119 @@
+package se.nullable.flickboard.model.layouts
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import se.nullable.flickboard.model.Action
+import se.nullable.flickboard.model.Direction
+import se.nullable.flickboard.model.KeyM
+import se.nullable.flickboard.model.Layer
+import se.nullable.flickboard.model.Layout
+import se.nullable.flickboard.ui.FlickBoardParent
+import se.nullable.flickboard.ui.Keyboard
+
+val PT_IOS_MESSAGEASE_MAIN_LAYER = Layer(
+    keyRows = listOf(
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("a"),
+                    Direction.TOP to Action.Text("ô"),
+                    Direction.TOP_RIGHT to Action.Text("â"),
+                    Direction.LEFT to Action.Text("ã"),
+                    Direction.BOTTOM to Action.Text("à"),
+                    Direction.BOTTOM_RIGHT to Action.Text("v")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("n"),
+                    Direction.TOP to Action.Text("ñ"),
+                    Direction.BOTTOM to Action.Text("l")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("i"),
+                    Direction.TOP_LEFT to Action.Text("í"),
+                    Direction.RIGHT to Action.Text("õ"),
+                    Direction.BOTTOM_LEFT to Action.Text("x")
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("d"),
+                    Direction.TOP to Action.Text("ü"),
+                    Direction.RIGHT to Action.Text("k"),
+                    Direction.BOTTOM to Action.Text("ç")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("o"),
+                    Direction.TOP_LEFT to Action.Text("q"),
+                    Direction.TOP to Action.Text("u"),
+                    Direction.TOP_RIGHT to Action.Text("p"),
+                    Direction.LEFT to Action.Text("c"),
+                    Direction.RIGHT to Action.Text("b"),
+                    Direction.BOTTOM_LEFT to Action.Text("g"),
+                    Direction.BOTTOM to Action.Text("h"),
+                    Direction.BOTTOM_RIGHT to Action.Text("j")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("r"),
+                    Direction.LEFT to Action.Text("m")
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("t"),
+                    Direction.TOP to Action.Text("ú"),
+                    Direction.TOP_RIGHT to Action.Text("y"),
+                    Direction.RIGHT to Action.Text("ê"),
+                    Direction.BOTTOM to Action.Text("ó")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("e"),
+                    Direction.TOP to Action.Text("w"),
+                    Direction.LEFT to Action.Text("é"),
+                    Direction.RIGHT to Action.Text("z")
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("s"),
+                    Direction.TOP_LEFT to Action.Text("f")
+                )
+            ),
+        ),
+        listOf(SPACE)
+    )
+)
+
+val PT_IOS_MESSAGEASE = Layout(
+    mainLayer = PT_IOS_MESSAGEASE_MAIN_LAYER,
+    controlLayer = CONTROL_MESSAGEASE_LAYER
+)
+
+@Composable
+@Preview
+fun PtIosKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = Layout(PT_IOS_MESSAGEASE_MAIN_LAYER), onAction = {})
+    }
+}
+
+@Composable
+@Preview
+fun PtIosFullKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = PT_IOS_MESSAGEASE, showAllModifiers = true, onAction = {})
+    }
+}

--- a/app/src/main/java/se/nullable/flickboard/model/layouts/PTMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/PTMessagEase.kt
@@ -10,7 +10,7 @@ import se.nullable.flickboard.model.Layout
 import se.nullable.flickboard.ui.FlickBoardParent
 import se.nullable.flickboard.ui.Keyboard
 
-val PT_AND_MESSAGEASE_MAIN_LAYER = Layer(
+val PT_MESSAGEASE_MAIN_LAYER = Layer(
     keyRows = listOf(
         listOf(
             KeyM(
@@ -93,23 +93,23 @@ val PT_AND_MESSAGEASE_MAIN_LAYER = Layer(
     )
 )
 
-val PT_AND_MESSAGEASE = Layout(
-    mainLayer = PT_AND_MESSAGEASE_MAIN_LAYER,
+val PT_MESSAGEASE = Layout(
+    mainLayer = PT_MESSAGEASE_MAIN_LAYER,
     controlLayer = CONTROL_MESSAGEASE_LAYER
 )
 
 @Composable
 @Preview
-fun PtAndKeyboardPreview() {
+fun PtKeyboardPreview() {
     FlickBoardParent {
-        Keyboard(layout = Layout(PT_AND_MESSAGEASE_MAIN_LAYER), onAction = {})
+        Keyboard(layout = Layout(PT_MESSAGEASE_MAIN_LAYER), onAction = {})
     }
 }
 
 @Composable
 @Preview
-fun PtAndFullKeyboardPreview() {
+fun PtFullKeyboardPreview() {
     FlickBoardParent {
-        Keyboard(layout = PT_AND_MESSAGEASE, showAllModifiers = true, onAction = {})
+        Keyboard(layout = PT_MESSAGEASE, showAllModifiers = true, onAction = {})
     }
 }

--- a/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
+++ b/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
@@ -91,10 +91,14 @@ import se.nullable.flickboard.model.layouts.ES_MESSAGEASE
 import se.nullable.flickboard.model.layouts.FR_EXT_MESSAGEASE
 import se.nullable.flickboard.model.layouts.FR_MESSAGEASE
 import se.nullable.flickboard.model.layouts.HU_MESSAGEASE
+import se.nullable.flickboard.model.layouts.HU_DT_MESSAGEASE
+import se.nullable.flickboard.model.layouts.HU_MF_MESSAGEASE
 import se.nullable.flickboard.model.layouts.HU_UUP_MESSAGEASE
 import se.nullable.flickboard.model.layouts.IT_MESSAGEASE
 import se.nullable.flickboard.model.layouts.MESSAGEASE_NUMERIC_CALCULATOR_LAYER
 import se.nullable.flickboard.model.layouts.MESSAGEASE_NUMERIC_PHONE_LAYER
+import se.nullable.flickboard.model.layouts.PT_AND_MESSAGEASE
+import se.nullable.flickboard.model.layouts.PT_IOS_MESSAGEASE
 import se.nullable.flickboard.model.layouts.RU_MESSAGEASE
 import se.nullable.flickboard.model.layouts.RU_PHONETIC_MESSAGEASE
 import se.nullable.flickboard.model.layouts.SV_DE_MESSAGEASE
@@ -973,8 +977,12 @@ enum class LetterLayerOption(override val label: String, val layout: Layout) : L
     German("German (MessagEase)", DE_MESSAGEASE),
     GermanEnglish("German/English (MessagEase)", EN_DE_MESSAGEASE),
     Hungarian("Hungarian (MessagEase)", HU_MESSAGEASE),
+    HungarianDT("Hungarian (MessagEase, by Dániel Tenke)", HU_DT_MESSAGEASE),
+    HungarianMF("Hungarian (MessagEase, by Máté Farkas)", HU_MF_MESSAGEASE),
     HungarianUUp("Hungarian (MessagEase, U always up)", HU_UUP_MESSAGEASE),
     Italian("Italian (MessagEase)", IT_MESSAGEASE),
+    PortugueseAnd("Portuguese (MessagEase, Android)", PT_AND_MESSAGEASE),
+    PortugueseIos("Portuguese (MessagEase, iOS)", PT_IOS_MESSAGEASE),
     Russian("Russian (MessagEase)", RU_MESSAGEASE),
     RussianPhonetic("Russian phonetic (MessagEase)", RU_PHONETIC_MESSAGEASE),
     Spanish("Spanish (MessagEase)", ES_MESSAGEASE),

--- a/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
+++ b/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
@@ -97,7 +97,7 @@ import se.nullable.flickboard.model.layouts.HU_UUP_MESSAGEASE
 import se.nullable.flickboard.model.layouts.IT_MESSAGEASE
 import se.nullable.flickboard.model.layouts.MESSAGEASE_NUMERIC_CALCULATOR_LAYER
 import se.nullable.flickboard.model.layouts.MESSAGEASE_NUMERIC_PHONE_LAYER
-import se.nullable.flickboard.model.layouts.PT_AND_MESSAGEASE
+import se.nullable.flickboard.model.layouts.PT_MESSAGEASE
 import se.nullable.flickboard.model.layouts.PT_IOS_MESSAGEASE
 import se.nullable.flickboard.model.layouts.RU_MESSAGEASE
 import se.nullable.flickboard.model.layouts.RU_PHONETIC_MESSAGEASE
@@ -981,7 +981,7 @@ enum class LetterLayerOption(override val label: String, val layout: Layout) : L
     HungarianMF("Hungarian (MessagEase, by Máté Farkas)", HU_MF_MESSAGEASE),
     HungarianUUp("Hungarian (MessagEase, U always up)", HU_UUP_MESSAGEASE),
     Italian("Italian (MessagEase)", IT_MESSAGEASE),
-    PortugueseAnd("Portuguese (MessagEase, Android)", PT_AND_MESSAGEASE),
+    Portuguese("Portuguese (MessagEase)", PT_MESSAGEASE),
     PortugueseIos("Portuguese (MessagEase, iOS)", PT_IOS_MESSAGEASE),
     Russian("Russian (MessagEase)", RU_MESSAGEASE),
     RussianPhonetic("Russian phonetic (MessagEase)", RU_PHONETIC_MESSAGEASE),

--- a/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
+++ b/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
@@ -90,6 +90,8 @@ import se.nullable.flickboard.model.layouts.EN_MESSAGEASE
 import se.nullable.flickboard.model.layouts.ES_MESSAGEASE
 import se.nullable.flickboard.model.layouts.FR_EXT_MESSAGEASE
 import se.nullable.flickboard.model.layouts.FR_MESSAGEASE
+import se.nullable.flickboard.model.layouts.HU_MESSAGEASE
+import se.nullable.flickboard.model.layouts.HU_UUP_MESSAGEASE
 import se.nullable.flickboard.model.layouts.MESSAGEASE_NUMERIC_CALCULATOR_LAYER
 import se.nullable.flickboard.model.layouts.MESSAGEASE_NUMERIC_PHONE_LAYER
 import se.nullable.flickboard.model.layouts.RU_MESSAGEASE
@@ -968,6 +970,8 @@ enum class LetterLayerOption(override val label: String, val layout: Layout) : L
     English("English (MessagEase)", EN_MESSAGEASE),
     German("German (MessagEase)", DE_MESSAGEASE),
     GermanEnglish("German/English (MessagEase)", EN_DE_MESSAGEASE),
+    Hungarian("Hungarian (MessagEase)", HU_MESSAGEASE),
+    HungarianUUp("Hungarian (MessagEase, U always up)", HU_UUP_MESSAGEASE),
     Russian("Russian (MessagEase)", RU_MESSAGEASE),
     RussianPhonetic("Russian phonetic (MessagEase)", RU_PHONETIC_MESSAGEASE),
     Spanish("Spanish (MessagEase)", ES_MESSAGEASE),


### PR DESCRIPTION
Closed the previous pull requests, because their ordering in Settings.kt would have required manual conflict resolution. This request could be automatically merged.

Layouts in request:

Hungarian
- official MessagEase
- by Dániel Tenke
- by Máté Farkas
- U always up

Italian
Portuguese
  - official MessagEase on Android
  - iOS

Turkish