### PR TITLE
Added ponctuation french layout

### DIFF
--- a/app/src/main/java/se/nullable/flickboard/model/layouts/FRPoncMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/FRPoncMessagEase.kt
@@ -1,0 +1,117 @@
+package se.nullable.flickboard.model.layouts
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import se.nullable.flickboard.model.Action
+import se.nullable.flickboard.model.Direction
+import se.nullable.flickboard.model.KeyM
+import se.nullable.flickboard.model.Layer
+import se.nullable.flickboard.model.Layout
+import se.nullable.flickboard.ui.FlickBoardParent
+import se.nullable.flickboard.ui.Keyboard
+
+val FR_MESSAGEASE_MAIN_LAYER = Layer(
+    keyRows = listOf(
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("a"),
+                    Direction.TOP to Action.Text("*"),
+                    Direction.TOP_RIGHT to Action.Text("à"),
+                    Direction.BOTTOM_RIGHT to Action.Text("v"),
+                    Direction.LEFT to Action.Text("«"),
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("n"),
+                    Direction.BOTTOM to Action.Text("l"),
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("i"),
+                    Direction.TOP_RIGHT to Action.Text("’"),
+                    Direction.TOP_LEFT to Action.Text("·"),
+                    Direction.RIGHT to Action.Text("»"),
+                    Direction.BOTTOM_LEFT to Action.Text("x"),
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("u"),
+                    Direction.TOP to Action.Text("ê"),
+                    Direction.RIGHT to Action.Text("k"),
+                    Direction.BOTTOM to Action.Text("ç"),
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("o"),
+                    Direction.TOP_LEFT to Action.Text("q"),
+                    Direction.TOP to Action.Text("h"),
+                    Direction.TOP_RIGHT to Action.Text("p"),
+                    Direction.RIGHT to Action.Text("b"),
+                    Direction.BOTTOM_RIGHT to Action.Text("j"),
+                    Direction.BOTTOM to Action.Text("d"),
+                    Direction.BOTTOM_LEFT to Action.Text("g"),
+                    Direction.LEFT to Action.Text("c"),
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("r"),
+                    Direction.LEFT to Action.Text("m"),
+                )
+            ),
+        ),
+        listOf(
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("t"),
+                    Direction.TOP_RIGHT to Action.Text("y"),
+                    Direction.RIGHT to Action.Text("è"),
+                    Direction.BOTTOM to Action.Text("ù"),
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("e"),
+                    Direction.TOP to Action.Text("w"),
+                    Direction.RIGHT to Action.Text("z"),
+                    Direction.LEFT to Action.Text("é"),
+                )
+            ),
+            KeyM(
+                actions = mapOf(
+                    Direction.CENTER to Action.Text("s"),
+                    Direction.TOP_LEFT to Action.Text("f"),
+                )
+            ),
+        ),
+        listOf(SPACE)
+    )
+)
+
+val FR_MESSAGEASE = Layout(
+    mainLayer = FR_PONC_MESSAGEASE_MAIN_LAYER,
+    controlLayer = CONTROL_MESSAGEASE_LAYER
+)
+
+@Composable
+@Preview
+fun FrKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = Layout(FR_PONC_MESSAGEASE_MAIN_LAYER), onAction = {})
+    }
+}
+
+@Composable
+@Preview
+fun FrFullKeyboardPreview() {
+    FlickBoardParent {
+        Keyboard(layout = FR_PONC_MESSAGEASE, onAction = {})
+    }
+}

--- a/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
+++ b/app/src/main/java/se/nullable/flickboard/ui/Settings.kt
@@ -90,6 +90,7 @@ import se.nullable.flickboard.model.layouts.DE_MESSAGEASE
 import se.nullable.flickboard.model.layouts.EN_DE_MESSAGEASE
 import se.nullable.flickboard.model.layouts.EN_MESSAGEASE
 import se.nullable.flickboard.model.layouts.ES_MESSAGEASE
+import se.nullable.flickboard.model.layouts.FR_PONC_MESSAGEASE
 import se.nullable.flickboard.model.layouts.FR_EXT_MESSAGEASE
 import se.nullable.flickboard.model.layouts.FR_MESSAGEASE
 import se.nullable.flickboard.model.layouts.HU_DT_MESSAGEASE
@@ -1122,6 +1123,7 @@ enum class LetterLayerOption(override val label: String, val layout: Layout) : L
     UkrainianRussian("Ukrainian Russian (MessagEase)", UK_RU_MESSAGEASE),
     French("French (MessagEase)", FR_MESSAGEASE),
     FrenchExt("French (Extended MessagEase)", FR_EXT_MESSAGEASE),
+    FrenchExt("French (Punctuation MessagEase)", FR_PONC_MESSAGEASE),
 }
 
 enum class NumericLayerOption(override val label: String, val layer: Layer) : Labeled {


### PR DESCRIPTION
Hello, I forked the "MessagEase FR" layout to make the changes I had made to my MessagEase.

The purpose of these modifications is to make punctuation marks specific to the French language accessible, such as our quotation marks «», our slanted apostrophe ’ and our median point · (for gender-neutral inclusive writing).
The umlaut ¨ and the asterisk *.

Here's an annotated screenshot of the layout I had on MessagEase:
![image](https://github.com/nightkr/flickboard/assets/1497894/c5ccabf4-3dc9-42c1-9598-38883eca2092)


