### PR TITLE
Provide uppercase “ẞ” for DE and EN/DE layouts

### DIFF
--- a/app/src/main/java/se/nullable/flickboard/model/layouts/DEMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/DEMessagEase.kt
@@ -68,6 +68,11 @@ val DE_MESSAGEASE_MAIN_LAYER = Layer(
                     Direction.CENTER to Action.Text("t"),
                     Direction.TOP_RIGHT to Action.Text("y"),
                     Direction.BOTTOM to Action.Text("ß")
+                ),
+                shift = KeyM(
+                    actions = mapOf(
+                        Direction.BOTTOM to Action.Text("ẞ")
+                    )
                 )
             ),
             KeyM(

--- a/app/src/main/java/se/nullable/flickboard/model/layouts/ENDEMessagEase.kt
+++ b/app/src/main/java/se/nullable/flickboard/model/layouts/ENDEMessagEase.kt
@@ -21,6 +21,11 @@ val EN_DE_MESSAGEASE_MAIN_LAYER = Layer(
                     Direction.LEFT to Action.Text("ä"),
                     Direction.BOTTOM to Action.Text("ü"),
                     Direction.BOTTOM_RIGHT to Action.Text("v")
+                ),
+                shift = KeyM(
+                    actions = mapOf(
+                        Direction.TOP_RIGHT to Action.Text("ẞ")
+                    )
                 )
             ),
             KeyM(


### PR DESCRIPTION
Only due to #183 I noticed that by default shifting the “ß” does not produce “ẞ”, but instead “SS”. While this is totally valid, I think a better default is to actually produce the uppercase “ẞ”.

This is not the most urgent issue. An “ß” never occurs at the beginning of a word and therfore the uppercase variant is rarely used. It is so rare that this character was only introduced as a valid character in 2017…

But this is now in line with the DE/EO layout that provides this character as well.

Are there any reasons _against_ doing this?